### PR TITLE
chore: move shikiji workaround 

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -728,6 +728,7 @@ export default defineConfigWithTheme<ThemeConfig>({
   },
 
   markdown: {
+    theme: 'github-dark',
     config(md) {
       md.use(headerPlugin)
       // .use(textAdPlugin)

--- a/.vitepress/theme/styles/index.css
+++ b/.vitepress/theme/styles/index.css
@@ -4,8 +4,3 @@
 @import "./inline-demo.css";
 @import "./utilities.css";
 @import "./style-guide.css";
-
-/* vitepress rc.31 migrated to shijiki and need this to apply code styles */
-.vp-code span {
-  color: var(--shiki-dark, inherit);
-}


### PR DESCRIPTION
resolves #null
Cherry picked from https://github.com/vuejs/docs/commit/95d5e5d21d2743def23ef6cc5a5a045e362bbc4f