### PR TITLE
chore(deps): bump vitepress from 1.0.1 to 1.0.2 (#126)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ dependencies:
     version: 4.1.1
   '@vue/theme':
     specifier: ^2.2.5
-    version: 2.2.5(vitepress@1.0.1)(vue@3.4.21)
+    version: 2.2.5(vitepress@1.0.2)(vue@3.4.21)
   dynamics.js:
     specifier: ^1.1.5
     version: 1.1.5
@@ -22,7 +22,7 @@ dependencies:
     version: 3.9.0
   vitepress:
     specifier: ^1.0.0
-    version: 1.0.1(@types/node@20.10.1)(terser@5.14.2)
+    version: 1.0.2(@types/node@20.10.1)(terser@5.14.2)
   vue:
     specifier: ^3.4.0
     version: 3.4.21
@@ -798,7 +798,7 @@ packages:
     resolution: {integrity: sha512-PuJe7vDIi6VYSinuEbUIQgMIRZGgM8e4R+G+/dQTk0X1NEdvgvvgv7m+rfmDH1gZzyA1OjjoWskvHlfRNfQf3g==}
     dev: false
 
-  /@vue/theme@2.2.5(vitepress@1.0.1)(vue@3.4.21):
+  /@vue/theme@2.2.5(vitepress@1.0.2)(vue@3.4.21):
     resolution: {integrity: sha512-UUPD0XxlRa69Ytely8JEU/cu8Pae5f4UqZNIXANPN8KT6j/O23dCbOfp1cKlSn+Q/xXLYp0K+vRh4IqZjt/9BQ==}
     peerDependencies:
       vitepress: ^1.0.0-alpha.60
@@ -808,7 +808,7 @@ packages:
       '@vueuse/core': 9.13.0(vue@3.4.21)
       body-scroll-lock: 3.1.5
       normalize.css: 8.0.1
-      vitepress: 1.0.1(@types/node@20.10.1)(terser@5.14.2)
+      vitepress: 1.0.2(@types/node@20.10.1)(terser@5.14.2)
     transitivePeerDependencies:
       - '@algolia/client-search'
       - '@types/react'
@@ -1199,8 +1199,8 @@ packages:
       fsevents: 2.3.3
     dev: false
 
-  /vitepress@1.0.1(@types/node@20.10.1)(terser@5.14.2):
-    resolution: {integrity: sha512-eNr5pOBppYUUjEhv8S0S2t9Tv95LQ6mMeHj6ivaGwfHxpov70Vduuwl/QQMDRznKDSaP0WKV7a82Pb4JVOaqEw==}
+  /vitepress@1.0.2(@types/node@20.10.1)(terser@5.14.2):
+    resolution: {integrity: sha512-bEj9yTEdWyewJFOhEREZF+mXuAgOq27etuJZT6DZSp+J3XpQstXMJc5piSVwhZBtuj8OfA0iXy+jdP1c71KMYQ==}
     hasBin: true
     peerDependencies:
       markdown-it-mathjax3: ^4


### PR DESCRIPTION
resolves #126
Cherry picked from https://github.com/vuejs/docs/commit/6cbe834fb0c6f285a1798c407b1fe412da3ae203