### PR TITLE
chore(deps): bump @vue/repl from 4.1.1 to 4.1.2 (#177)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
 dependencies:
   '@vue/repl':
     specifier: ^4.0.1
-    version: 4.1.1
+    version: 4.1.2
   '@vue/theme':
     specifier: ^2.2.5
     version: 2.2.5(vitepress@1.1.3)(vue@3.4.25)
@@ -765,8 +765,8 @@ packages:
       '@vue/shared': 3.4.25
     dev: false
 
-  /@vue/repl@4.1.1:
-    resolution: {integrity: sha512-gkbnU+rM01/ILdnDJbsWS8+PW6qMAzprBo/U2+7eVci0kx6VAR26fL/qrcEPwEYa6q0vzzptZ4il0SaUGGqZKw==}
+  /@vue/repl@4.1.2:
+    resolution: {integrity: sha512-h5JQ5NRN9HOCNfE4QCbZsFgAFS7/A21V3zrltxV2Uag1JIvtQb68qfmj795CPFjMBnRNpCddOBi34AKlq5yHbg==}
     dev: false
 
   /@vue/runtime-core@3.4.25:


### PR DESCRIPTION
resolves #177
Cherry picked from https://github.com/vuejs/docs/commit/0112f1aa6a5709f3c5d7d711369c4e992cecbf60