### PR TITLE
fix: correctly link to i18n custom blocks (#222)

### DIFF
--- a/src/api/sfc-spec.md
+++ b/src/api/sfc-spec.md
@@ -66,7 +66,7 @@ Do souboru `*.vue` můžete navíc přidat další vlastní bloky pro potřeby k
 
 - [Gridsome: `<page-query>`](https://gridsome.org/docs/querying-data/)
 - [vite-plugin-vue-gql: `<gql>`](https://github.com/wheatjs/vite-plugin-vue-gql)
-- [vue-i18n: `<i18n>`](https://github.com/intlify/bundle-tools/tree/main/packages/vite-plugin-vue-i18n#i18n-custom-block)
+- [vue-i18n: `<i18n>`](https://github.com/intlify/bundle-tools/tree/main/packages/unplugin-vue-i18n#i18n-custom-block)
 
 Zpracování vlastních bloků závisí na nástrojích - pokud chcete vytvořit vlastní integrace, podívejte se pro další informace na sekci [Nástroje pro integraci vlastních SFC bloků](/guide/scaling-up/tooling#sfc-custom-block-integrations).
 


### PR DESCRIPTION
resolves #222
Cherry picked from https://github.com/vuejs/docs/commit/7493b263972c078e39db3b3e4b41ac3e01f5f539