### PR TITLE
chore(deps): bump vitepress from 1.3.1 to 1.3.2 (#302)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
         version: 4.3.1
       '@vue/theme':
         specifier: ^2.2.12
-        version: 2.2.12(@algolia/client-search@4.23.3)(search-insights@2.14.0)(vitepress@1.3.1(@algolia/client-search@4.23.3)(@types/node@20.14.1)(postcss@8.4.40)(search-insights@2.14.0)(terser@5.31.0)(typescript@5.4.5))(vue@3.4.35(typescript@5.4.5))
+        version: 2.2.12(@algolia/client-search@4.23.3)(search-insights@2.14.0)(vitepress@1.3.2(@algolia/client-search@4.23.3)(@types/node@20.14.1)(postcss@8.4.40)(search-insights@2.14.0)(terser@5.31.0)(typescript@5.4.5))(vue@3.4.35(typescript@5.4.5))
       dynamics.js:
         specifier: ^1.1.5
         version: 1.1.5
@@ -22,7 +22,7 @@ importers:
         version: 3.12.5
       vitepress:
         specifier: ^1.2.3
-        version: 1.3.1(@algolia/client-search@4.23.3)(@types/node@20.14.1)(postcss@8.4.40)(search-insights@2.14.0)(terser@5.31.0)(typescript@5.4.5)
+        version: 1.3.2(@algolia/client-search@4.23.3)(@types/node@20.14.1)(postcss@8.4.40)(search-insights@2.14.0)(terser@5.31.0)(typescript@5.4.5)
       vue:
         specifier: ^3.4.27
         version: 3.4.35(typescript@5.4.5)
@@ -493,9 +493,6 @@ packages:
     peerDependencies:
       vue: 3.4.35
 
-  '@vue/shared@3.4.31':
-    resolution: {integrity: sha512-Yp3wtJk//8cO4NItOPpi3QkLExAr/aLBGZMmTtW9WpdwBCJpRM6zj9WgWktXAl8IDIozwNMByT45JP3tO3ACWA==}
-
   '@vue/shared@3.4.33':
     resolution: {integrity: sha512-aoRY0jQk3A/cuvdkodTrM4NMfxco8n55eG4H7ML/CRy7OryHfiqvug4xrCBBMbbN+dvXAetDDwZW9DXWWjBntA==}
 
@@ -678,10 +675,6 @@ packages:
   picocolors@1.0.1:
     resolution: {integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==}
 
-  postcss@8.4.39:
-    resolution: {integrity: sha512-0vzE+lAiG7hZl1/9I8yzKLx3aR9Xbof3fBHKunvMfOCYAtMhrsnccJY2iTURb9EZd5+pLuiNV9/c/GZJOHsgIw==}
-    engines: {node: ^10 || ^12 || >=14}
-
   postcss@8.4.40:
     resolution: {integrity: sha512-YF2kKIUzAofPMpfH6hOi2cGnv/HrUlfucspc7pDyvv7kGdqXrfj8SCl/t8owkEgKEuu8ZcRjSOxFxVLqwChZ2Q==}
     engines: {node: ^10 || ^12 || >=14}
@@ -778,8 +771,8 @@ packages:
       terser:
         optional: true
 
-  vitepress@1.3.1:
-    resolution: {integrity: sha512-soZDpg2rRVJNIM/IYMNDPPr+zTHDA5RbLDHAxacRu+Q9iZ2GwSR0QSUlLs+aEZTkG0SOX1dc8RmUYwyuxK8dfQ==}
+  vitepress@1.3.2:
+    resolution: {integrity: sha512-6gvecsCuR6b1Cid4w19KQiQ02qkpgzFRqiG0v1ZBekGkrZCzsxdDD5y4WH82HRXAOhU4iZIpzA1CsWqs719rqA==}
     hasBin: true
     peerDependencies:
       markdown-it-mathjax3: ^4
@@ -1217,7 +1210,7 @@ snapshots:
     dependencies:
       '@volar/language-core': 2.2.5
       '@vue/compiler-dom': 3.4.33
-      '@vue/shared': 3.4.33
+      '@vue/shared': 3.4.35
       computeds: 0.0.1
       minimatch: 9.0.4
       path-browserify: 1.0.1
@@ -1249,13 +1242,11 @@ snapshots:
       '@vue/shared': 3.4.35
       vue: 3.4.35(typescript@5.4.5)
 
-  '@vue/shared@3.4.31': {}
-
   '@vue/shared@3.4.33': {}
 
   '@vue/shared@3.4.35': {}
 
-  '@vue/theme@2.2.12(@algolia/client-search@4.23.3)(search-insights@2.14.0)(vitepress@1.3.1(@algolia/client-search@4.23.3)(@types/node@20.14.1)(postcss@8.4.40)(search-insights@2.14.0)(terser@5.31.0)(typescript@5.4.5))(vue@3.4.35(typescript@5.4.5))':
+  '@vue/theme@2.2.12(@algolia/client-search@4.23.3)(search-insights@2.14.0)(vitepress@1.3.2(@algolia/client-search@4.23.3)(@types/node@20.14.1)(postcss@8.4.40)(search-insights@2.14.0)(terser@5.31.0)(typescript@5.4.5))(vue@3.4.35(typescript@5.4.5))':
     dependencies:
       '@docsearch/css': 3.6.0
       '@docsearch/js': 3.6.0(@algolia/client-search@4.23.3)(search-insights@2.14.0)
@@ -1263,7 +1254,7 @@ snapshots:
       body-scroll-lock: 4.0.0-beta.0
       normalize.css: 8.0.1
       tiny-decode: 0.1.3
-      vitepress: 1.3.1(@algolia/client-search@4.23.3)(@types/node@20.14.1)(postcss@8.4.40)(search-insights@2.14.0)(terser@5.31.0)(typescript@5.4.5)
+      vitepress: 1.3.2(@algolia/client-search@4.23.3)(@types/node@20.14.1)(postcss@8.4.40)(search-insights@2.14.0)(terser@5.31.0)(typescript@5.4.5)
     transitivePeerDependencies:
       - '@algolia/client-search'
       - '@types/react'
@@ -1439,12 +1430,6 @@ snapshots:
 
   picocolors@1.0.1: {}
 
-  postcss@8.4.39:
-    dependencies:
-      nanoid: 3.3.7
-      picocolors: 1.0.1
-      source-map-js: 1.2.0
-
   postcss@8.4.40:
     dependencies:
       nanoid: 3.3.7
@@ -1523,14 +1508,14 @@ snapshots:
   vite@5.3.3(@types/node@20.14.1)(terser@5.31.0):
     dependencies:
       esbuild: 0.21.5
-      postcss: 8.4.39
+      postcss: 8.4.40
       rollup: 4.18.0
     optionalDependencies:
       '@types/node': 20.14.1
       fsevents: 2.3.3
       terser: 5.31.0
 
-  vitepress@1.3.1(@algolia/client-search@4.23.3)(@types/node@20.14.1)(postcss@8.4.40)(search-insights@2.14.0)(terser@5.31.0)(typescript@5.4.5):
+  vitepress@1.3.2(@algolia/client-search@4.23.3)(@types/node@20.14.1)(postcss@8.4.40)(search-insights@2.14.0)(terser@5.31.0)(typescript@5.4.5):
     dependencies:
       '@docsearch/css': 3.6.0
       '@docsearch/js': 3.6.0(@algolia/client-search@4.23.3)(search-insights@2.14.0)
@@ -1539,7 +1524,7 @@ snapshots:
       '@types/markdown-it': 14.1.1
       '@vitejs/plugin-vue': 5.0.5(vite@5.3.3(@types/node@20.14.1)(terser@5.31.0))(vue@3.4.35(typescript@5.4.5))
       '@vue/devtools-api': 7.3.5
-      '@vue/shared': 3.4.31
+      '@vue/shared': 3.4.35
       '@vueuse/core': 10.11.0(vue@3.4.35(typescript@5.4.5))
       '@vueuse/integrations': 10.11.0(focus-trap@7.5.4)(vue@3.4.35(typescript@5.4.5))
       focus-trap: 7.5.4

--- a/src/guide/quick-start.md
+++ b/src/guide/quick-start.md
@@ -46,7 +46,11 @@ Zkontrolujte, že máte nainstalovanou nejnovější verzi [Node.js](https://nod
   <VTCodeGroupTab label="yarn">
   
   ```sh
+  # For Yarn Modern (v2+)
   $ yarn create vue@latest
+  
+  # For Yarn ^v4.11
+  $ yarn dlx create-vue@latest
   ```
 
   </VTCodeGroupTab>

--- a/src/guide/scaling-up/tooling.md
+++ b/src/guide/scaling-up/tooling.md
@@ -43,7 +43,11 @@ Pro zahájení práce s Vite + Vue jednoduše spusťte:
   <VTCodeGroupTab label="yarn">
 
   ```sh
+  # For Yarn Modern (v2+)
   $ yarn create vue@latest
+  
+  # For Yarn ^v4.11
+  $ yarn dlx create-vue@latest
   ```
 
   </VTCodeGroupTab>


### PR DESCRIPTION
resolves #302
Cherry picked from https://github.com/vuejs/docs/commit/1113c8a634a871bc6867f957927c7f576de4f4f7